### PR TITLE
Diversity and Coverage Scores

### DIFF
--- a/src/configuration/lipizzaner-gan/mnist_diverse.yml
+++ b/src/configuration/lipizzaner-gan/mnist_diverse.yml
@@ -18,8 +18,9 @@ trainer:
     score:
       enabled: True
       type: prdc
-      score_sample_size: 10000
+      score_sample_size: 1000
       cuda: True
+      nearest_k: 5
     fitness:
       fitness_sample_size: 1000
       fitness_mode: average # worse, best, average

--- a/src/configuration/lipizzaner-gan/mnist_diverse.yml
+++ b/src/configuration/lipizzaner-gan/mnist_diverse.yml
@@ -17,8 +17,8 @@ trainer:
     enable_selection: True
     score:
       enabled: True
-      type: fid
-      score_sample_size: 1000
+      type: prdc
+      score_sample_size: 10000
       cuda: True
     fitness:
       fitness_sample_size: 1000

--- a/src/networks/competetive_net.py
+++ b/src/networks/competetive_net.py
@@ -176,15 +176,15 @@ class GeneratorNet(CompetetiveNet):
                                         create_graph=True, retain_graph=True, only_inputs=True)
             with torch.no_grad():
                 allgrad = gradients[0]
-                for i, grad in enumerate(gradients[1:]):
+                for grad in gradients[1:]:
                     grad = grad.view(-1)
-                    allgrad = torch.cat([allgrad,grad]) 
+                    allgrad = torch.cat([allgrad,grad])
 
             Fd = -torch.log(torch.norm(allgrad)).data.cpu().numpy()
             Fq = self.loss_function(fake_outputs, real_labels)
-            
+
             return alpha*Fd + beta*Fq, fake_images, None
-            
+
         else:
             fake_images = self.net(z)
             outputs = opponent.net(fake_images).view(-1)

--- a/src/training/mixture/prdc_score.py
+++ b/src/training/mixture/prdc_score.py
@@ -1,0 +1,28 @@
+import logging
+
+import numpy as np
+import torch
+from helpers.configuration_container import ConfigurationContainer
+from training.mixture.score_calculator import ScoreCalculator
+
+
+class PRDCCalculator(ScoreCalculator):
+    _logger = logging.getLogger(__name__)
+
+    def __init__(
+        self,
+        cuda=True,
+        verbose=False,
+    ):
+        pass
+        # self.model = cargar MNISTCnn para conseguir los "emmbedings". Chequear si tiene softmax ya hecho
+
+    def calculate(self, imgs, exact=True):
+        pass
+        # conseguir las clasificaciones para las reales y las fake
+        # pasarle por el prdc
+        # hacerle F1 al dc y dejarlo (f1, {})
+
+    @property
+    def is_reversed(self):
+        return False

--- a/src/training/mixture/prdc_score.py
+++ b/src/training/mixture/prdc_score.py
@@ -11,15 +11,7 @@ from training.mixture.score_calculator import ScoreCalculator
 class PRDCCalculator(ScoreCalculator):
     _logger = logging.getLogger(__name__)
 
-    def __init__(
-        self,
-        imgs_original,
-        batch_size=64,
-        dims=10,
-        n_samples=10000,
-        cuda=True,
-        verbose=False,
-    ):
+    def __init__(self, imgs_original, batch_size=64, dims=10, n_samples=10000, cuda=True, verbose=False, nearest_k=5):
         """
         :param imgs_original: The original dataset, e.g. torcvision.datasets.CIFAR10
         :param batch_size: Batch size that will be used, 64 is recommended.
@@ -36,9 +28,10 @@ class PRDCCalculator(ScoreCalculator):
         self.verbose = verbose
         self.dataset = self.cc.settings["dataloader"]["dataset_name"]
         self.network = self.cc.settings["network"]["name"]
+        self.nearest_k = nearest_k
         self.dims = dims  # For MNIST the dimension of feature map is 10
 
-    def calculate(self, imgs, exact=True, nearest_k=10):
+    def calculate(self, imgs, exact=True):
         """
         Calculates the Manifold Precision, Manifold Recall, Density and Coverage of two PyTorch datasets, which must have the same dimensions.
 
@@ -60,7 +53,7 @@ class PRDCCalculator(ScoreCalculator):
         real_act = self.get_activations(self.imgs_original, model)
         fake_act = self.get_activations(imgs, model)
 
-        metrics = compute_prdc(real_features=real_act, fake_features=fake_act, nearest_k=nearest_k)
+        metrics = compute_prdc(real_features=real_act, fake_features=fake_act, nearest_k=self.nearest_k)
         harmonic_mean = 2 * (metrics["density"] * metrics["coverage"]) / (metrics["density"] + metrics["coverage"])
 
         return harmonic_mean, metrics

--- a/src/training/mixture/prdc_score.py
+++ b/src/training/mixture/prdc_score.py
@@ -3,6 +3,9 @@ import logging
 import numpy as np
 import torch
 from helpers.configuration_container import ConfigurationContainer
+from prdc import compute_prdc
+from torch.autograd import Variable
+from training.mixture.fid_mnist import MNISTCnn
 from training.mixture.score_calculator import ScoreCalculator
 
 
@@ -11,17 +14,116 @@ class PRDCCalculator(ScoreCalculator):
 
     def __init__(
         self,
+        imgs_original,
+        batch_size=64,
+        dims=10,
+        n_samples=10000,
         cuda=True,
         verbose=False,
     ):
-        pass
-        # self.model = cargar MNISTCnn para conseguir los "emmbedings". Chequear si tiene softmax ya hecho
+        """
+        :param imgs_original: The original dataset, e.g. torcvision.datasets.CIFAR10
+        :param batch_size: Batch size that will be used, 64 is recommended.
+        :param cuda: If True, the GPU will be used.
+        :param dims: Dimensionality of Emmbeding features to use. By default, uses MNIST features.
+        :param n_samples: In the paper, min. 10k samples are suggested.
+        :param verbose: Verbose logging
+        """
+        self.cc = ConfigurationContainer.instance()
+        self.imgs_original = imgs_original
+        self.batch_size = batch_size
+        self.n_samples = n_samples
+        self.cuda = cuda
+        self.verbose = verbose
+        self.dataset = self.cc.settings["dataloader"]["dataset_name"]
+        self.network = self.cc.settings["network"]["name"]
+        self.dims = dims  # For MNIST the dimension of feature map is 10
 
-    def calculate(self, imgs, exact=True):
-        pass
-        # conseguir las clasificaciones para las reales y las fake
-        # pasarle por el prdc
-        # hacerle F1 al dc y dejarlo (f1, {})
+    def calculate(self, imgs, exact=True, nearest_k=10):
+        """
+        Calculates the Manifold Precision, Manifold Recall, Density and Coverage of two PyTorch datasets, which must have the same dimensions.
+
+        :param imgs: PyTorch dataset containing the generated images. (Could be both grey or RGB images)
+        :return: Harmonic mean of Density and Coverage and dict(PRDC)
+        """
+        model = None
+        if self.dataset == "mnist":  # Gray dataset
+            model = MNISTCnn()
+            model.load_state_dict(torch.load("./output/networks/mnist_cnn.pkl"))
+        else:  # Other RGB dataset
+            # TODO: Add Dynamic definition of ConvNet.
+            #       With matching input size to dataset and output size to self.dims.
+            raise Exception('Datset {} is not supported. Use "MNIST".'.format(self.dataset))
+
+        if self.cuda:
+            model.cuda()
+
+        real_act = self.get_activations(self.imgs_original, model)
+        fake_act = self.get_activations(imgs, model)
+
+        metrics = compute_prdc(real_features=real_act, fake_features=fake_act, nearest_k=nearest_k)
+        harmonic_mean = 2 * (metrics["density"] * metrics["coverage"]) / (metrics["density"] + metrics["coverage"])
+
+        return harmonic_mean, metrics
+
+    def get_activations(self, images, model):
+        """Calculates the activations of the pool_3 layer for all images.
+
+        Params:
+        -- images      : Numpy array of dimension (n_images, 3, hi, wi). The values
+                         must lie between 0 and 1.
+        -- model       : Instance of inception model
+        -- batch_size  : the images numpy array is split into batches with
+                         batch size batch_size. A reasonable batch size depends
+                         on the hardware.
+        -- dims        : Dimensionality of features returned by Inception
+
+        Returns:
+        -- A numpy array of dimension (num images, dims) that contains the
+           activations of the given tensor when feeding inception with the
+           query tensor.
+        """
+        model.eval()
+
+        # Reshape to 2D images as required by MNISTCnn class
+        images = [img.view(-1, 28, 28) for img in images]
+
+        d0 = len(images)
+        if self.batch_size > d0:
+            print(("Warning: batch size is bigger than the data size. " "Setting batch size to data size"))
+            self.batch_size = d0
+
+        n_batches = d0 // self.batch_size
+        n_used_imgs = n_batches * self.batch_size
+
+        pred_arr = np.empty((n_used_imgs, self.dims))
+        for i in range(n_batches):
+            if self.verbose:
+                print(
+                    "\rPropagating batch %d/%d" % (i + 1, n_batches),
+                    end="",
+                    flush=True,
+                )
+            start = i * self.batch_size
+            end = start + self.batch_size
+
+            batch = torch.stack(images[start:end])
+            batch = Variable(batch, volatile=True)
+            if self.cuda:
+                batch = batch.cuda()
+            else:
+                # .cpu() is required to convert to torch.FloatTensor because image
+                # might be generated using CUDA and in torch.cuda.FloatTensor
+                batch = batch.cpu()
+
+            pred = model(batch)[0]
+
+            pred_arr[start:end] = pred.cpu().data.numpy().reshape(self.batch_size, -1)
+
+        if self.verbose:
+            print(" done")
+
+        return pred_arr
 
     @property
     def is_reversed(self):

--- a/src/training/mixture/prdc_score.py
+++ b/src/training/mixture/prdc_score.py
@@ -77,10 +77,15 @@ class PRDCCalculator(ScoreCalculator):
         """
         model.eval()
 
-        # Reshape to 2D images as required by MNISTCnn class
-        images = [img.view(-1, 28, 28) for img in images]
+        final_images = []
+        assert len(images) >= self.n_samples, "Cannot draw enough samples from dataset"
 
-        d0 = len(images)
+        for i in range(self.n_samples):
+            # Reshape to 2D images as required by MNISTCnn class
+            img = images[i].view(-1, 28, 28)
+            final_images.append(img)
+
+        d0 = len(final_images)
         if self.batch_size > d0:
             print(("Warning: batch size is bigger than the data size. " "Setting batch size to data size"))
             self.batch_size = d0
@@ -100,7 +105,7 @@ class PRDCCalculator(ScoreCalculator):
                 start = i * self.batch_size
                 end = start + self.batch_size
 
-                batch = torch.stack(images[start:end])
+                batch = torch.stack(final_images[start:end])
                 batch = torch.tensor(batch)
                 if self.cuda:
                     batch = batch.cuda()

--- a/src/training/mixture/score_factory.py
+++ b/src/training/mixture/score_factory.py
@@ -76,6 +76,7 @@ class ScoreCalculatorFactory:
                 IgnoreLabelDataset(dataset),
                 cuda=cc.settings["master"].get("cuda", False),
                 n_samples=settings["score"].get("score_sample_size", 10000),
+                nearest_k=settings["score"].get("nearest_k", 5),
             )
         else:
             raise Exception(


### PR DESCRIPTION
This PR introduces an implementation of ["Reliable Fidelity and Diversity Metrics for Generative Models"](https://arxiv.org/abs/2002.09797) to be used as a scoring metric for the generator models.

Being two scores, we use the Harmonic Mean between the two to draw the final result.
the output of the Scorer is then:
`(harmonic_mean, {'precision':[0-1], 'recall':[0-1], 'density':[0-1], 'coverage':[0-1]})`
Being a tuple with the aforementioned harmonic mean first and a dictionary containing the two values for density and coverage along with the classic precision and recall scores. This last two aren't considered in the final result.

Using this tuple form allows for the value to be used in the sort function for model selection without trouble.
As an extension the harmonic mean could be replaced by weighted params. 